### PR TITLE
chore: Add description to rust crates we want to release

### DIFF
--- a/.github/workflows/rust-crates-publish.yml
+++ b/.github/workflows/rust-crates-publish.yml
@@ -25,11 +25,11 @@ jobs:
           toolchain: 1.66.0
 
       # These steps are in a specific order so crate dependencies are updated first
-      # - name: Publish bls12_381
-      #   run: |
-      #     cargo publish --package crate_crypto_internal_peerdas_bls12_381
-      #   env:
-      #     CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_RELEASE_TOKEN }}
+      - name: Publish bls12_381
+        run: |
+          cargo publish --package crate_crypto_internal_peerdas_bls12_381
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_RELEASE_TOKEN }}
 
       - name: Publish polynomial
         run: |

--- a/.github/workflows/rust-crates-publish.yml
+++ b/.github/workflows/rust-crates-publish.yml
@@ -25,11 +25,11 @@ jobs:
           toolchain: 1.66.0
 
       # These steps are in a specific order so crate dependencies are updated first
-      - name: Publish bls12_381
-        run: |
-          cargo publish --package crate_crypto_internal_peerdas_bls12_381
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_RELEASE_TOKEN }}
+      # - name: Publish bls12_381
+      #   run: |
+      #     cargo publish --package crate_crypto_internal_peerdas_bls12_381
+      #   env:
+      #     CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_RELEASE_TOKEN }}
 
       - name: Publish polynomial
         run: |

--- a/bls12_381/Cargo.toml
+++ b/bls12_381/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "crate_crypto_internal_peerdas_bls12_381"
+description = "This crate provides the internal implementation of the BLS12-381 curve for the Peerdas project."
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/eip7594/Cargo.toml
+++ b/eip7594/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "eip7594"
+description = "This crate provides an implementation of the cryptography needed for EIP-7594"
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/kzg_multi_open/Cargo.toml
+++ b/kzg_multi_open/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "crate_crypto_kzg_multi_open_fk20"
+description = "This crate provides a multi-opening algorithm for KZG10 using FK20"
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/polynomial/Cargo.toml
+++ b/polynomial/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "crate_crypto_internal_peerdas_polynomial"
+description = "This crate provides utility methods that are needed for Polynomial objects"
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
Crates.io does not allow you to release crates that have no description