### PR TITLE
chore(ci): remove portable flag on blst

### DIFF
--- a/bls12_381/Cargo.toml
+++ b/bls12_381/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 [dependencies]
 rayon = { workspace = true }
 
-blst = { version = "0.3.1", default-features = false, features = ["portable"] }
+blst = { version = "0.3.1", default-features = false }
 
 # __private_bench feature is used to allow us to access the base field
 blstrs = { version = "0.7.1", features = ["__private_bench"] }


### PR DESCRIPTION
This seems to be somewhat broken when cross compiling from mac (arm) to Mac(x86-64) using zigbuild. We can mitigate this by not cross compiling and running dedicated mac machines for each cpu.

Error message:

```
The following warnings were emitted during compilation:

warning: blst@0.3.11: zig: warning: overriding '-mmacosx-version-min=14.5' option with '-target x86_64-unknown-macosx11.7.1-unknown' [-Woverriding-option]
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:1472:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:6555:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:6673:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:6809:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:6945:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7079:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7306:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7501:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7559:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7882:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7961:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:8089:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:8557:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:8625:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:8711:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9158:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9353:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9416:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9678:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: /var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9754:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^

error: failed to run custom build command for `blst v0.3.11`

Caused by:
  process didn't exit successfully: `/Users/kev/work/crate-crypto/peerdas-kzg/target/release/build/blst-d07e4020a0d2124c/build-script-build` (exit status: 1)
  --- stdout
  cargo:rustc-cfg=feature="std"
  cargo:rerun-if-env-changed=BLST_TEST_NO_STD
  Using blst source directory /Users/kev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blst-0.3.11/blst
  cargo:rerun-if-changed=/Users/kev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blst-0.3.11/blst/src
  cargo:rerun-if-changed=/Users/kev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blst-0.3.11/blst/build
  Compiling in portable mode without ISA extensions
  TARGET = Some("x86_64-apple-darwin")
  HOST = Some("aarch64-apple-darwin")
  cargo:rerun-if-env-changed=CC_x86_64-apple-darwin
  CC_x86_64-apple-darwin = None
  cargo:rerun-if-env-changed=CC_x86_64_apple_darwin
  CC_x86_64_apple_darwin = Some("/Users/kev/Library/Caches/cargo-zigbuild/0.19.0/zigcc-x86_64-apple-darwin-db1e.sh")
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("false")
  cargo:rerun-if-env-changed=CFLAGS_x86_64-apple-darwin
  CFLAGS_x86_64-apple-darwin = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_apple_darwin
  CFLAGS_x86_64_apple_darwin = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-apple-darwin
  CFLAGS_x86_64-apple-darwin = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_apple_darwin
  CFLAGS_x86_64_apple_darwin = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-apple-darwin
  CFLAGS_x86_64-apple-darwin = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_apple_darwin
  CFLAGS_x86_64_apple_darwin = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-apple-darwin
  CFLAGS_x86_64-apple-darwin = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_apple_darwin
  CFLAGS_x86_64_apple_darwin = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64-apple-darwin
  CFLAGS_x86_64-apple-darwin = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_apple_darwin
  CFLAGS_x86_64_apple_darwin = None
  cargo:rerun-if-env-changed=TARGET_CFLAGS
  TARGET_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:warning=zig: warning: overriding '-mmacosx-version-min=14.5' option with '-target x86_64-unknown-macosx11.7.1-unknown' [-Woverriding-option]
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:1472:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:6555:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:6673:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:6809:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:6945:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7079:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7306:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7501:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7559:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7882:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:7961:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:8089:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:8557:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:8625:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:8711:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9158:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9353:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9416:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9678:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^
  cargo:warning=/var/folders/_9/vnrwx10x7znbs5bqwnvx4tn80000gn/T/assembly-35b5f5.s:9754:1: error: invalid CFI advance_loc expression
  cargo:warning=.cfi_adjust_cfa_offset 8
  cargo:warning=^

  --- stderr


  error occurred: Command env -u IPHONEOS_DEPLOYMENT_TARGET "/Users/kev/Library/Caches/cargo-zigbuild/0.19.0/zigcc-x86_64-apple-darwin-db1e.sh" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "--target=x86_64-apple-darwin" "-mmacosx-version-min=14.5" "-Wall" "-Wextra" "-mno-avx" "-fno-builtin" "-Wno-unused-function" "-Wno-unused-command-line-argument" "-D__BLST_PORTABLE__" "-o" "/Users/kev/work/crate-crypto/peerdas-kzg/target/x86_64-apple-darwin/release/build/blst-439629dda423a73e/out/1952448bf4ffb9d0-assembly.o" "-c" "/Users/kev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blst-0.3.11/blst/build/assembly.S" with args zigcc-x86_64-apple-darwin-db1e.sh did not execute successfully (status code exit status: 1).


warning: build failed, waiting for other jobs to finish...
```