### PR TITLE
feat: FK20 now only computes proofs

### DIFF
--- a/eip7594/src/prover.rs
+++ b/eip7594/src/prover.rs
@@ -100,7 +100,7 @@ impl ProverContext {
     }
 
     /// Computes the KZG commitment to the polynomial represented by the blob.
-    /// 
+    ///
     /// Note: Currently this is the only place we use the lagrange form of the commitment key
     /// We could get rid of it entirely, at the cost of an IDFT.
     pub fn blob_to_kzg_commitment(&self, blob: BlobRef) -> Result<KZGCommitment, ProverError> {
@@ -147,14 +147,14 @@ impl ProverContext {
         &self,
         poly_coeff: Vec<Scalar>,
     ) -> Result<([Cell; CELLS_PER_EXT_BLOB], [KZGProof; CELLS_PER_EXT_BLOB]), ProverError> {
-
-        // Check the degree of the polynomial. 
+        // Check the degree of the polynomial.
         // All polynomials in monomial form at this level of the API, have the same degree.
         assert_eq!(FIELD_ELEMENTS_PER_BLOB, poly_coeff.len());
 
         // Compute the proofs and the evaluation sets for the polynomial.
-        let (proofs, evaluation_sets) = self.fk20.compute_multi_opening_proofs(poly_coeff);
+        let proofs = self.fk20.compute_multi_opening_proofs(poly_coeff.clone());
 
+        let evaluation_sets = self.fk20.compute_evaluation_sets(poly_coeff);
         // Serialize the evaluation sets into `Cell`s.
         let cells = serialization::evaluation_sets_to_cells(evaluation_sets.into_iter());
 

--- a/kzg_multi_open/src/fk20/naive.rs
+++ b/kzg_multi_open/src/fk20/naive.rs
@@ -65,11 +65,10 @@ pub fn compute_h_poly(polynomial: &PolyCoeff, l: usize) -> Vec<&[Scalar]> {
 pub fn fk20_open_multi_point(
     commit_key: &CommitKey,
     proof_domain: &Domain,
-    ext_domain: &Domain,
     polynomial: &PolyCoeff,
-    l: usize,
-) -> (Vec<G1Point>, Vec<Vec<Scalar>>) {
-    let h_polys = compute_h_poly(polynomial, l);
+    coset_size: usize,
+) -> Vec<G1Point> {
+    let h_polys = compute_h_poly(polynomial, coset_size);
     let commitment_h_polys = h_polys
         .iter()
         .map(|h_poly| commit_key.commit_g1(h_poly))
@@ -80,19 +79,26 @@ pub fn fk20_open_multi_point(
     // TODO: This does not seem to be using the batch affine trick
     bls12_381::G1Projective::batch_normalize(&proofs, &mut proofs_affine);
 
-    // Compute the evaluations of the polynomial at the cosets by doing an fft
-    let mut evaluations = ext_domain.fft_scalars(polynomial.clone());
-    reverse_bit_order(&mut evaluations);
-    let set_of_output_points: Vec<_> = evaluations
-        .chunks_exact(l)
-        .map(|slice| slice.to_vec())
-        .collect();
-
     // reverse the order of the proofs, since fft_g1 was applied using
     // the regular order.
     reverse_bit_order(&mut proofs_affine);
 
-    (proofs_affine, set_of_output_points)
+    proofs_affine
+}
+
+pub fn fk20_compute_evaluation_set(
+    polynomial: &PolyCoeff,
+    coset_size: usize,
+    ext_domain: Domain,
+) -> Vec<Vec<Scalar>> {
+    // Compute the evaluations of the polynomial at the cosets by doing an fft
+    let mut evaluations = ext_domain.fft_scalars(polynomial.clone());
+    reverse_bit_order(&mut evaluations);
+
+    evaluations
+        .chunks_exact(coset_size)
+        .map(|slice| slice.to_vec())
+        .collect()
 }
 
 #[cfg(test)]

--- a/kzg_multi_open/src/naive.rs
+++ b/kzg_multi_open/src/naive.rs
@@ -25,6 +25,14 @@ pub struct Proof {
 
 /// Naively computes an opening proof that attests to the evaluation of
 /// `polynomial` at `input_points`.
+//
+// Note: This method returns both the proof and the output points.
+// This does not follow the convention of the other methods which
+// produce proofs.
+//
+// This is done intentionally since that method
+// has additional checks that require the evaluations and computing
+// the output points, the naive way is quite expensive.
 pub fn compute_multi_opening(
     commit_key: &CommitKey,
     polynomial: &PolyCoeff,


### PR DESCRIPTION
This separates proof generation and computing the evaluation sets from FK20. This is do that we can push it to the caller and then compute the evaluation sets in the reed-solomon crate.