### PR TITLE
chore!: Move all prover and verifier methods to PeerDAS context object

### DIFF
--- a/bindings/c/src/blob_to_kzg_commitment.rs
+++ b/bindings/c/src/blob_to_kzg_commitment.rs
@@ -12,7 +12,7 @@ pub(crate) fn _blob_to_kzg_commitment(
 
     // Dereference the input pointers
     //
-    let ctx = deref_const(ctx).prover_ctx();
+    let ctx = deref_const(ctx).inner();
     let blob = create_array_ref::<BYTES_PER_BLOB, _>(blob);
 
     // Computation

--- a/bindings/c/src/compute_cells_and_kzg_proofs.rs
+++ b/bindings/c/src/compute_cells_and_kzg_proofs.rs
@@ -12,7 +12,7 @@ pub(crate) fn _compute_cells_and_kzg_proofs(
 
     // Pointer checks
     //
-    let ctx = deref_const(ctx).prover_ctx();
+    let ctx = deref_const(ctx).inner();
     let blob = create_array_ref::<BYTES_PER_BLOB, _>(blob);
 
     // Computation

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -30,12 +30,16 @@ pub struct PeerDASContext {
 }
 
 impl PeerDASContext {
+    #[deprecated(note = "Prover and Verifier context will be merged")]
     pub fn prover_ctx(&self) -> &eip7594::prover::ProverContext {
         self.inner.prover_ctx()
     }
-
+    #[deprecated(note = "Prover and Verifier context will be merged")]
     pub fn verifier_ctx(&self) -> &eip7594::verifier::VerifierContext {
         &self.inner.verifier_ctx
+    }
+    pub fn inner(&self) -> &eip7594::PeerDASContext {
+        &self.inner
     }
 }
 

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -35,8 +35,6 @@ impl PeerDASContext {
     }
 }
 
-// TODO: Add this into eip7594 spec tests
-
 /// Create a new PeerDASContext and return a pointer to it.
 ///
 /// # Memory faults

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -30,14 +30,6 @@ pub struct PeerDASContext {
 }
 
 impl PeerDASContext {
-    #[deprecated(note = "Prover and Verifier context will be merged")]
-    pub fn prover_ctx(&self) -> &eip7594::prover::ProverContext {
-        self.inner.prover_ctx()
-    }
-    #[deprecated(note = "Prover and Verifier context will be merged")]
-    pub fn verifier_ctx(&self) -> &eip7594::verifier::VerifierContext {
-        &self.inner.verifier_ctx
-    }
     pub fn inner(&self) -> &eip7594::PeerDASContext {
         &self.inner
     }

--- a/bindings/c/src/recover_cells_and_kzg_proofs.rs
+++ b/bindings/c/src/recover_cells_and_kzg_proofs.rs
@@ -17,7 +17,7 @@ pub(crate) fn _recover_cells_and_proofs(
 
     // Dereference the input pointers
     //
-    let ctx = deref_const(ctx).prover_ctx();
+    let ctx = deref_const(ctx).inner();
     let cells = ptr_ptr_to_vec_slice_const::<BYTES_PER_CELL>(cells, cells_length as usize);
     let cell_indices = create_slice_view(cell_indices, cell_indices_length as usize);
 

--- a/bindings/c/src/verify_cells_and_kzg_proofs.rs
+++ b/bindings/c/src/verify_cells_and_kzg_proofs.rs
@@ -17,7 +17,7 @@ pub(crate) fn _verify_cell_kzg_proof(
 
     // Dereference the input pointers
     //
-    let ctx = deref_const(ctx).verifier_ctx();
+    let ctx = deref_const(ctx).inner();
     let cell = create_array_ref::<BYTES_PER_CELL, _>(cell);
     let commitment = create_array_ref::<BYTES_PER_COMMITMENT, _>(commitment);
     let proof = create_array_ref::<BYTES_PER_COMMITMENT, _>(proof);

--- a/bindings/c/src/verify_cells_and_kzg_proofs_batch.rs
+++ b/bindings/c/src/verify_cells_and_kzg_proofs_batch.rs
@@ -43,7 +43,7 @@ pub(crate) fn _verify_cell_kzg_proof_batch(
 
     // Dereference the input pointers
     //
-    let ctx = deref_const(ctx).verifier_ctx();
+    let ctx = deref_const(ctx).inner();
     let row_commitments = ptr_ptr_to_vec_slice_const::<BYTES_PER_COMMITMENT>(
         row_commitments,
         row_commitments_length as usize,

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -13,6 +13,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextNe
     _env: JNIEnv,
     _class: JClass,
 ) -> jlong {
+    // TODO: Switch to using the Rust PeerDASContext object
     c_peerdas_kzg::peerdas_context_new() as jlong
 }
 
@@ -22,6 +23,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextDe
     _class: JClass,
     ctx_ptr: jlong,
 ) {
+    // TODO: Switch to using the Rust PeerDASContext object
     c_peerdas_kzg::peerdas_context_free(ctx_ptr as *mut PeerDASContext);
 }
 
@@ -49,7 +51,7 @@ fn compute_cells_and_kzg_proofs<'local>(
     let blob = env.convert_byte_array(blob)?;
     let blob = slice_to_array_ref(&blob, "blob")?;
 
-    let (cells, proofs) = ctx.prover_ctx().compute_cells_and_kzg_proofs(blob)?;
+    let (cells, proofs) = ctx.inner().compute_cells_and_kzg_proofs(blob)?;
     let cells = cells.map(|cell| *cell);
     cells_and_proofs_to_jobject(env, &cells, &proofs).map_err(Error::from)
 }
@@ -78,7 +80,7 @@ fn blob_to_kzg_commitment<'local>(
     let blob = env.convert_byte_array(blob)?;
     let blob = slice_to_array_ref(&blob, "blob")?;
 
-    let commitment = ctx.prover_ctx().blob_to_kzg_commitment(blob)?;
+    let commitment = ctx.inner().blob_to_kzg_commitment(blob)?;
     env.byte_array_from_slice(&commitment).map_err(Error::from)
 }
 
@@ -233,7 +235,7 @@ fn recover_cells_and_kzg_proofs<'local>(
         .collect::<Result<_, _>>()?;
 
     let (recovered_cells, recovered_proofs) =
-        ctx.prover_ctx().recover_cells_and_proofs(cell_ids, cells)?;
+        ctx.inner().recover_cells_and_proofs(cell_ids, cells)?;
     let recovered_cells = recovered_cells.map(|cell| *cell);
     cells_and_proofs_to_jobject(env, &recovered_cells, &recovered_proofs).map_err(Error::from)
 }

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -124,7 +124,7 @@ fn verify_cell_kzg_proof(
     let proof = slice_to_array_ref(&proof, "proof")?;
 
     match ctx
-        .verifier_ctx()
+        .inner()
         .verify_cell_kzg_proof(commitment, cell_id, cell, proof)
     {
         Ok(_) => Ok(jboolean::from(true)),
@@ -190,7 +190,7 @@ fn verify_cell_kzg_proof_batch<'local>(
         .map(|proof| slice_to_array_ref(proof, "proof"))
         .collect::<Result<_, _>>()?;
 
-    match ctx.verifier_ctx().verify_cell_kzg_proof_batch(
+    match ctx.inner().verify_cell_kzg_proof_batch(
         commitments,
         row_indices,
         column_indices,

--- a/bindings/node/__test__/index.spec.ts
+++ b/bindings/node/__test__/index.spec.ts
@@ -1,6 +1,6 @@
 import {
-  ProverContextJs,
-  VerifierContextJs,
+  PeerDasContextJs,
+  PeerDASContextJs,
 } from "../index.js";
 
 import { readFileSync } from "fs";
@@ -27,7 +27,7 @@ type VerifyCellKzgProofBatchTest = TestMeta<
   { row_commitments: string[]; row_indices: number[]; column_indices: number[]; cells: string[]; proofs: string[] },
   boolean
 >;
-type RecoverCellsAndKzgProofsTest = TestMeta<{cell_indices: number[]; cells: string[]}, string[][]>;
+type RecoverCellsAndKzgProofsTest = TestMeta<{ cell_indices: number[]; cells: string[] }, string[][]>;
 
 /**
  * Converts hex string to binary Uint8Array
@@ -63,7 +63,7 @@ function assertBytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): void 
 }
 
 describe("ProverContext", () => {
-  const proverContext = new ProverContextJs();
+  const ctx = new PeerDasContextJs();
 
   it("reference tests for blobToKzgCommitment should pass", () => {
     const tests = globSync(BLOB_TO_KZG_COMMITMENT_TESTS);
@@ -76,7 +76,7 @@ describe("ProverContext", () => {
       const blob = bytesFromHex(test.input.blob);
 
       try {
-        commitment = proverContext.blobToKzgCommitment(blob);
+        commitment = ctx.blobToKzgCommitment(blob);
       } catch (err) {
         expect(test.output).toBeNull();
         return;
@@ -99,7 +99,7 @@ describe("ProverContext", () => {
       const blob = bytesFromHex(test.input.blob);
 
       try {
-        cells_and_proofs = proverContext.computeCellsAndKzgProofs(blob);
+        cells_and_proofs = ctx.computeCellsAndKzgProofs(blob);
       } catch (err) {
         expect(test.output).toBeNull();
         return;
@@ -135,7 +135,7 @@ describe("ProverContext", () => {
       const cells = test.input.cells.map(bytesFromHex);
 
       try {
-        recoveredCellsAndProofs = proverContext.recoverCellsAndKzgProofs(cellIndices, cells);
+        recoveredCellsAndProofs = ctx.recoverCellsAndKzgProofs(cellIndices, cells);
       } catch (err) {
         expect(test.output).toBeNull();
         return;
@@ -159,11 +159,6 @@ describe("ProverContext", () => {
     });
   });
 
-});
-
-describe("VerifierContext", () => {
-  const verifierContext = new VerifierContextJs();
-
   it("reference tests for verifyCellKzgProofBatch should pass", () => {
     const tests = globSync(VERIFY_CELL_KZG_PROOF_BATCH_TESTS);
     expect(tests.length).toBeGreaterThan(0);
@@ -179,7 +174,7 @@ describe("VerifierContext", () => {
       const proofs = test.input.proofs.map(bytesFromHex);
 
       try {
-        valid = verifierContext.verifyCellKzgProofBatch(rowCommitments, rowIndices, columnIndices, cells, proofs);
+        valid = ctx.verifyCellKzgProofBatch(rowCommitments, rowIndices, columnIndices, cells, proofs);
       } catch (err) {
         expect(test.output).toBeNull();
         return;
@@ -204,7 +199,7 @@ describe("VerifierContext", () => {
       const proof = bytesFromHex(test.input.proof);
 
       try {
-        valid = verifierContext.verifyCellKzgProof(commitment, cellId, cell, proof);
+        valid = ctx.verifyCellKzgProof(commitment, cellId, cell, proof);
       } catch (err) {
         expect(test.output).toBeNull();
         return;
@@ -213,4 +208,6 @@ describe("VerifierContext", () => {
       expect(valid).toEqual(test.output);
     });
   });
+
+
 });

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -13,7 +13,8 @@ export class CellsAndProofs {
   cells: Array<Uint8Array>
   proofs: Array<Uint8Array>
 }
-export class ProverContextJs {
+export type PeerDASContextJs = PeerDasContextJs
+export class PeerDasContextJs {
   constructor()
   blobToKzgCommitment(blob: Uint8Array): Uint8Array
   asyncBlobToKzgCommitment(blob: Uint8Array): Promise<Uint8Array>
@@ -21,13 +22,10 @@ export class ProverContextJs {
   asyncComputeCellsAndKzgProofs(blob: Uint8Array): Promise<CellsAndProofs>
   computeCells(blob: Uint8Array): Array<Uint8Array>
   asyncComputeCells(blob: Uint8Array): Promise<Array<Uint8Array>>
-  recoverCellsAndKzgProofs(cellIds: Array<bigint>, cells: Array<Uint8Array>): CellsAndProofs
-  asyncRecoverCellsAndKzgProofs(cellIds: Array<bigint>, cells: Array<Uint8Array>): Promise<CellsAndProofs>
-}
-export class VerifierContextJs {
-  constructor()
-  verifyCellKzgProof(commitment: Uint8Array, cellId: bigint, cell: Uint8Array, proof: Uint8Array): boolean
-  asyncVerifyCellKzgProof(commitment: Uint8Array, cellId: bigint, cell: Uint8Array, proof: Uint8Array): Promise<boolean>
+  recoverCellsAndKzgProofs(cellIndices: Array<bigint>, cells: Array<Uint8Array>): CellsAndProofs
+  asyncRecoverCellsAndKzgProofs(cellIndices: Array<bigint>, cells: Array<Uint8Array>): Promise<CellsAndProofs>
+  verifyCellKzgProof(commitment: Uint8Array, cellIndex: bigint, cell: Uint8Array, proof: Uint8Array): boolean
+  asyncVerifyCellKzgProof(commitment: Uint8Array, cellIndex: bigint, cell: Uint8Array, proof: Uint8Array): Promise<boolean>
   verifyCellKzgProofBatch(commitments: Array<Uint8Array>, rowIndices: Array<bigint>, columnIndices: Array<bigint>, cells: Array<Uint8Array>, proofs: Array<Uint8Array>): boolean
   asyncVerifyCellKzgProofBatch(commitments: Array<Uint8Array>, rowIndices: Array<bigint>, columnIndices: Array<bigint>, cells: Array<Uint8Array>, proofs: Array<Uint8Array>): Promise<boolean>
 }

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { BYTES_PER_COMMITMENT, BYTES_PER_PROOF, BYTES_PER_FIELD_ELEMENT, BYTES_PER_BLOB, MAX_NUM_COLUMNS, BYTES_PER_CELL, CellsAndProofs, ProverContextJs, VerifierContextJs } = nativeBinding
+const { BYTES_PER_COMMITMENT, BYTES_PER_PROOF, BYTES_PER_FIELD_ELEMENT, BYTES_PER_BLOB, MAX_NUM_COLUMNS, BYTES_PER_CELL, CellsAndProofs, PeerDasContextJs } = nativeBinding
 
 module.exports.BYTES_PER_COMMITMENT = BYTES_PER_COMMITMENT
 module.exports.BYTES_PER_PROOF = BYTES_PER_PROOF
@@ -319,5 +319,4 @@ module.exports.BYTES_PER_BLOB = BYTES_PER_BLOB
 module.exports.MAX_NUM_COLUMNS = MAX_NUM_COLUMNS
 module.exports.BYTES_PER_CELL = BYTES_PER_CELL
 module.exports.CellsAndProofs = CellsAndProofs
-module.exports.ProverContextJs = ProverContextJs
-module.exports.VerifierContextJs = VerifierContextJs
+module.exports.PeerDasContextJs = PeerDasContextJs

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -8,8 +8,8 @@ use napi_derive::napi;
 
 use eip7594::{
   constants,
-  prover::ProverContext,
   verifier::{VerifierContext, VerifierError},
+  PeerDASContext,
 };
 
 #[napi]
@@ -33,7 +33,7 @@ pub struct CellsAndProofs {
 
 #[napi]
 pub struct ProverContextJs {
-  inner: Arc<ProverContext>,
+  inner: Arc<PeerDASContext>,
 }
 
 impl Default for ProverContextJs {
@@ -47,7 +47,7 @@ impl ProverContextJs {
   #[napi(constructor)]
   pub fn new() -> Self {
     ProverContextJs {
-      inner: Arc::new(ProverContext::default()),
+      inner: Arc::new(PeerDASContext::default()),
     }
   }
 

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -6,11 +6,7 @@ use napi::{
 };
 use napi_derive::napi;
 
-use eip7594::{
-  constants,
-  verifier::{VerifierContext, VerifierError},
-  PeerDASContext,
-};
+use eip7594::{constants, verifier::VerifierError, PeerDASContext};
 
 #[napi]
 pub const BYTES_PER_COMMITMENT: u32 = constants::BYTES_PER_COMMITMENT as u32;
@@ -175,7 +171,7 @@ impl ProverContextJs {
 
 #[napi]
 pub struct VerifierContextJs {
-  inner: Arc<VerifierContext>,
+  inner: Arc<PeerDASContext>,
 }
 
 impl Default for VerifierContextJs {
@@ -189,7 +185,7 @@ impl VerifierContextJs {
   #[napi(constructor)]
   pub fn new() -> Self {
     VerifierContextJs {
-      inner: Arc::new(VerifierContext::default()),
+      inner: Arc::new(PeerDASContext::default()),
     }
   }
 

--- a/eip7594/benches/benchmark.rs
+++ b/eip7594/benches/benchmark.rs
@@ -2,7 +2,7 @@ use bls12_381::Scalar;
 use criterion::{criterion_group, criterion_main, Criterion};
 use eip7594::{
     constants::{BYTES_PER_BLOB, CELLS_PER_EXT_BLOB},
-    trusted_setup, Cell, KZGCommitment, KZGProof, PeerDASContext, VerifierContext,
+    trusted_setup, Cell, KZGCommitment, KZGProof, PeerDASContext,
 };
 
 const POLYNOMIAL_LEN: usize = 4096;
@@ -84,14 +84,10 @@ pub fn bench_verify_cell_kzg_proofs(c: &mut Criterion) {
     let (commitment, (cells, proofs)) = dummy_commitment_cells_and_proofs();
 
     for num_threads in THREAD_COUNTS {
-        let verifier_context = VerifierContext::with_num_threads(&trusted_setup, num_threads);
+        let ctx = PeerDASContext::with_threads(&trusted_setup, num_threads);
         c.bench_function(
             &format!("verify_cell_kzg_proof - NUM_THREADS: {}", num_threads),
-            |b| {
-                b.iter(|| {
-                    verifier_context.verify_cell_kzg_proof(&commitment, 0, &cells[0], &proofs[0])
-                })
-            },
+            |b| b.iter(|| ctx.verify_cell_kzg_proof(&commitment, 0, &cells[0], &proofs[0])),
         );
     }
 }

--- a/eip7594/src/prover.rs
+++ b/eip7594/src/prover.rs
@@ -141,9 +141,7 @@ impl PeerDASContext {
         self.prover_ctx.thread_pool.install(|| {
             // Recover polynomial
             //
-            let poly_coeff = self
-                .verifier_ctx
-                .recover_polynomial_coeff(cell_indices, cells)?;
+            let poly_coeff = self.recover_polynomial_coeff(cell_indices, cells)?;
 
             // Compute proofs and evaluation sets
             //

--- a/eip7594/src/prover.rs
+++ b/eip7594/src/prover.rs
@@ -126,7 +126,7 @@ impl PeerDASContext {
             let (proofs, evaluation_sets) = self
                 .prover_ctx
                 .fk20
-                .compute_multi_opening_proofs_poly_coeff(poly_coeff.clone());
+                .compute_multi_opening_proofs_poly_coeff(poly_coeff);
 
             Ok(serialization::serialize_cells_and_proofs(
                 evaluation_sets,

--- a/eip7594/tests/blob_to_kzg_commitment.rs
+++ b/eip7594/tests/blob_to_kzg_commitment.rs
@@ -62,7 +62,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/blob_to_kzg_commitment";
 fn test_blob_to_kzg_commitment() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let prover_context = eip7594::prover::ProverContext::default();
+    let ctx = eip7594::PeerDASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).unwrap();
@@ -78,7 +78,7 @@ fn test_blob_to_kzg_commitment() {
             }
         };
 
-        match prover_context.blob_to_kzg_commitment(blob) {
+        match ctx.blob_to_kzg_commitment(blob) {
             Ok(commitment) => {
                 let expected_commitment = test.commitment.unwrap();
 

--- a/eip7594/tests/compute_cells_and_kzg_proofs.rs
+++ b/eip7594/tests/compute_cells_and_kzg_proofs.rs
@@ -76,7 +76,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/compute_cells_and_kzg_proofs";
 fn test_compute_cells_and_kzg_proofs() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let prover_context = eip7594::prover::ProverContext::default();
+    let ctx = eip7594::PeerDASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).unwrap();
@@ -90,7 +90,7 @@ fn test_compute_cells_and_kzg_proofs() {
             }
         };
 
-        match prover_context.compute_cells_and_kzg_proofs(&blob) {
+        match ctx.compute_cells_and_kzg_proofs(&blob) {
             Ok((cells, proofs)) => {
                 let expected_proofs_and_cells = test.proofs_and_cells.unwrap();
 

--- a/eip7594/tests/recover_cells_and_compute_proofs.rs
+++ b/eip7594/tests/recover_cells_and_compute_proofs.rs
@@ -81,7 +81,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/recover_cells_and_kzg_proofs";
 fn test_recover_cells_and_proofs() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let ctx = eip7594::prover::ProverContext::default();
+    let ctx = eip7594::PeerDASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(&test_file).unwrap();

--- a/eip7594/tests/verify_cell_kzg_proof.rs
+++ b/eip7594/tests/verify_cell_kzg_proof.rs
@@ -66,7 +66,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/verify_cell_kzg_proof";
 fn test_verify_cell_kzg_proof() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let verifier_context = eip7594::verifier::VerifierContext::default();
+    let ctx = eip7594::PeerDASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(&test_file).unwrap();
@@ -94,7 +94,7 @@ fn test_verify_cell_kzg_proof() {
             }
         };
 
-        match verifier_context.verify_cell_kzg_proof(&commitment, test.cell_id, &cell, &proof) {
+        match ctx.verify_cell_kzg_proof(&commitment, test.cell_id, &cell, &proof) {
             Ok(_) => {
                 // We arrive at this point if the proof verified as true
                 assert!(test.output.unwrap())

--- a/eip7594/tests/verify_cell_kzg_proof_batch.rs
+++ b/eip7594/tests/verify_cell_kzg_proof_batch.rs
@@ -85,7 +85,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/verify_cell_kzg_proof_batch";
 fn test_verify_cell_kzg_proof_batch() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let verifier_context = eip7594::verifier::VerifierContext::default();
+    let ctx = eip7594::PeerDASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(&test_file).unwrap();
@@ -136,7 +136,7 @@ fn test_verify_cell_kzg_proof_batch() {
             }
         };
 
-        match verifier_context.verify_cell_kzg_proof_batch(
+        match ctx.verify_cell_kzg_proof_batch(
             commitments,
             test.row_indices,
             test.column_indices,


### PR DESCRIPTION
This PR moves all prover and verifier methods to peerdas context, since downstream callers were combining these two methods anyways.

We will keep the two structures, since they are good for separating resources. But they will not be exposed in the API anymore