### PR TITLE
chore!: Make Cell be a Vec<u8>

### DIFF
--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -52,7 +52,6 @@ fn compute_cells_and_kzg_proofs<'local>(
     let blob = slice_to_array_ref(&blob, "blob")?;
 
     let (cells, proofs) = ctx.inner().compute_cells_and_kzg_proofs(blob)?;
-    let cells = cells.map(|cell| *cell);
     cells_and_proofs_to_jobject(env, &cells, &proofs).map_err(Error::from)
 }
 
@@ -236,7 +235,6 @@ fn recover_cells_and_kzg_proofs<'local>(
 
     let (recovered_cells, recovered_proofs) =
         ctx.inner().recover_cells_and_proofs(cell_ids, cells)?;
-    let recovered_cells = recovered_cells.map(|cell| *cell);
     cells_and_proofs_to_jobject(env, &recovered_cells, &recovered_proofs).map_err(Error::from)
 }
 

--- a/eip7594/src/lib.rs
+++ b/eip7594/src/lib.rs
@@ -17,7 +17,7 @@ pub type Bytes48Ref<'a> = &'a [u8; 48];
 
 // TODO: We require a bit of feedback re usage to know whether we should make
 // TODO: Cell type just be Vec<u8> -- This would avoid accidental stack overflows.
-pub type Cell = Box<[u8; BYTES_PER_CELL]>;
+pub type Cell = Vec<u8>;
 pub type CellRef<'a> = &'a [u8; BYTES_PER_CELL];
 
 pub type KZGProof = [u8; BYTES_PER_COMMITMENT];

--- a/eip7594/src/trusted_setup.rs
+++ b/eip7594/src/trusted_setup.rs
@@ -1,13 +1,10 @@
 use bls12_381::{G1Point, G2Point};
 use kzg_multi_open::{commit_key::CommitKey, opening_key::OpeningKey};
-use rust_embed::Embed;
 use serde::Deserialize;
 
 use crate::constants::{FIELD_ELEMENTS_PER_BLOB, FIELD_ELEMENTS_PER_CELL};
 
-#[derive(Embed)]
-#[folder = "data"]
-struct EmbeddedData;
+pub const TRUSTED_SETUP_JSON: &str = include_str!("../data/trusted_setup_4096.json");
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 pub struct TrustedSetup {
@@ -109,14 +106,7 @@ impl TrustedSetup {
 
     /// Loads the official trusted setup file being used on mainnet from the embedded data folder.
     fn from_embed() -> TrustedSetup {
-        const TRUSTED_SETUP_FILE_NAME: &str = "trusted_setup_4096.json";
-
-        let file = EmbeddedData::get(TRUSTED_SETUP_FILE_NAME)
-            .expect("expected the trusted setup file to be embedded in the binary");
-        let json_str = std::str::from_utf8(file.data.as_ref())
-            .expect("expected the trusted setup file to be valid utf8");
-
-        Self::from_json(json_str)
+        Self::from_json(TRUSTED_SETUP_JSON)
     }
 }
 


### PR DESCRIPTION
This is a preemptive PR to check whether the current issue downstream users are facing is due to `Box<[u8; BYTES_PER_CELL]>`

This would mean that the compiler is still sometimes allocating large arrays on the stack.