### PR TITLE
chore: add correct Vector capacity to hash buffer in `compute_fiat_shamir_challenge`

### DIFF
--- a/bindings/java/rust_code/ethereum_cryptography_LibPeerDASKZG.h
+++ b/bindings/java/rust_code/ethereum_cryptography_LibPeerDASKZG.h
@@ -53,14 +53,6 @@ JNIEXPORT jbyteArray JNICALL Java_ethereum_cryptography_LibPeerDASKZG_blobToKZGC
 
 /*
  * Class:     ethereum_cryptography_LibPeerDASKZG
- * Method:    verifyCellKZGProof
- * Signature: (J[BJ[B[B)Z
- */
-JNIEXPORT jboolean JNICALL Java_ethereum_cryptography_LibPeerDASKZG_verifyCellKZGProof
-  (JNIEnv *, jclass, jlong, jbyteArray, jlong, jbyteArray, jbyteArray);
-
-/*
- * Class:     ethereum_cryptography_LibPeerDASKZG
  * Method:    verifyCellKZGProofBatch
  * Signature: (J[[B[J[J[[B[[B)Z
  */

--- a/eip7594/benches/benchmark.rs
+++ b/eip7594/benches/benchmark.rs
@@ -110,14 +110,13 @@ pub fn bench_verify_cell_kzg_proof_batch(c: &mut Criterion) {
 }
 
 pub fn bench_init_context(c: &mut Criterion) {
-    const NUM_THREADS : usize = 1;
-    c.bench_function(
-        &format!("Initialize context"),
-        |b| b.iter(|| {
+    const NUM_THREADS: usize = 1;
+    c.bench_function(&format!("Initialize context"), |b| {
+        b.iter(|| {
             let trusted_setup = trusted_setup::TrustedSetup::default();
             PeerDASContext::with_threads(&trusted_setup, NUM_THREADS)
-        }),
-    );
+        })
+    });
 }
 
 criterion_group!(

--- a/eip7594/src/trusted_setup.rs
+++ b/eip7594/src/trusted_setup.rs
@@ -112,7 +112,10 @@ impl TrustedSetup {
 
 /// Deserialize G1 points from hex strings without checking that the element
 /// is in the correct subgroup.
-fn deserialize_g1_points<T: AsRef<str>>(g1_points_hex_str: &[T], check: SubgroupCheck) -> Vec<G1Point> {
+fn deserialize_g1_points<T: AsRef<str>>(
+    g1_points_hex_str: &[T],
+    check: SubgroupCheck,
+) -> Vec<G1Point> {
     let mut g1_points = Vec::new();
     for g1_hex_str in g1_points_hex_str {
         let g1_hex_str = g1_hex_str.as_ref();
@@ -146,7 +149,6 @@ fn deserialize_g2_points<T: AsRef<str>>(
     g2_points_hex_str: &[T],
     subgroup_check: SubgroupCheck,
 ) -> Vec<G2Point> {
-
     let mut g2_points = Vec::new();
     for g2_hex_str in g2_points_hex_str {
         let g2_hex_str = g2_hex_str.as_ref();

--- a/erasure_codes/src/reed_solomon.rs
+++ b/erasure_codes/src/reed_solomon.rs
@@ -8,13 +8,13 @@ use polynomial::{domain::Domain, monomial::vanishing_poly};
 ///
 /// This is useful as it allows us to optimize the construction of
 /// the vanishing polynomial. This is by far the most time consuming part
-/// of unique decoding.  
+/// of unique decoding.
 pub(crate) enum ErasurePattern {
     /// Given a block_size, we can group the codeword into blocks.
     /// A block erasure index now signifies
     /// an erasure in the same position of each block.
     /// Example:
-    ///  - Codeword = [0,b,0,d,0,f,0, h]
+    ///  - Codeword = [0,b,0,d,0,f,0,h]
     ///  - block_size = 2
     ///  - block_index = 0
     /// In the above example, we had 4 blocks and
@@ -36,7 +36,7 @@ pub struct BlockErasureIndices(pub Vec<BlockErasureIndex>);
 
 #[derive(Debug)]
 pub struct ReedSolomon {
-    /// expansion_factor denotes the factor by which the message/poly_len will be expanded.
+    /// Denotes the factor by which the message/poly_len will be expanded.
     /// Example, if poly_len = 2 and expansion_factor = 4, Then the codeword will have length 4 * 2 = 8.
     expansion_factor: usize,
     /// The length of the polynomial that we will be encoding to a codeword.
@@ -87,7 +87,7 @@ impl ReedSolomon {
 
     /// Returns the maximum number of known missing values that we can
     /// tolerate before are not able to recover the message.
-    ///  
+    ///
     /// Note: we need to have at least `poly_len` evaluations
     fn acceptable_num_random_erasures(&self) -> usize {
         let total_codeword_len = self.poly_len * self.expansion_factor;
@@ -197,7 +197,7 @@ impl ReedSolomon {
         // Where \omega is a `num_blocks` root of unity.
         let mut z_x = vec![Scalar::ZERO; evaluation_domain_size];
         for (i, coeff) in vanish_poly_first_block.into_iter().enumerate() {
-            // Lets compute the bounds for the array access below to argue that it is safe:
+            // Let's compute the bounds for the array access below to argue that it is safe:
             //
             //  For all array accesses to be in bound, we have:
             //  i * self.num_blocks < z_x.len()

--- a/kzg_multi_open/src/fk20/cosets.rs
+++ b/kzg_multi_open/src/fk20/cosets.rs
@@ -162,7 +162,7 @@ mod tests {
 
             assert_eq!(coset_set, bit_reversed_set);
 
-            // A set will remove duplicates, for sanity, lets check that the lengths are the same
+            // A set will remove duplicates, for sanity, let's check that the lengths are the same
             // after we converted the vectors to sets.
             assert_eq!(coset_set.len(), coset_len);
             assert_eq!(bit_reversed_set.len(), coset_len);
@@ -217,7 +217,7 @@ mod tests {
             coset_evaluations.push(evaluations)
         }
 
-        // Lets explain how the data is distributed:
+        // Let's explain how the data is distributed:
         //
         // Because the cosets are formed by essentially shifting a smaller subgroup
         // by \omega^0, \omega^1, \omega^2, each point in the coset is equally spaced
@@ -248,7 +248,7 @@ mod tests {
         let got_coset_evaluations = take_every_nth(&extended_evaluations, 128);
         assert_eq!(got_coset_evaluations, coset_evaluations);
 
-        // Lets now extract the original data
+        // Let's now extract the original data
         let transposed_coset_evaluations = transpose(got_coset_evaluations);
         let flattened_transposed_evaluations: Vec<_> =
             transposed_coset_evaluations.into_iter().flatten().collect();

--- a/kzg_multi_open/src/fk20/prover.rs
+++ b/kzg_multi_open/src/fk20/prover.rs
@@ -205,7 +205,7 @@ impl FK20Prover {
     ///   - The idea is that a particular coset evaluation is evenly distributed across the set of flattened
     ///     evaluations.
     ///   Example:
-    ///     - Lets say we have `k` cosets. Each coset holds `m` values. Each coset will have an associated index.
+    ///     - Let's say we have `k` cosets. Each coset holds `m` values. Each coset will have an associated index.
     ///     - Once this method has completed, we will be given a flattened set of evaluations where the
     ///       `m` values in each coset are now a distance of `k` values apart from each other.
     ///     - The first value that was in the first coset, will be in position `0`.
@@ -249,7 +249,7 @@ impl FK20Prover {
         //
         // The greatest index we will be using is:
         // `t = coset_index * coset_len`
-        // lets denote the returned vectors length as `k`
+        // Let's denote the returned vectors length as `k`
         // We want t < k
         // => coset_index * coset_len < k
         // => coset_index < k / coset_len


### PR DESCRIPTION
Primarily, this PR improves `compute_fiat_shamir_challenge` by making the `hash_input` definition more readable. I immediately wanted to do this, then I saw your TODO comment so I decided to do it. I haven't benchmarked it, but I really don't expect it to make any difference. Also added an assert at the bottom to ensure the size calculation is right.