### PR TITLE
chore: Rename PeerDASContext -> DASContext

### DIFF
--- a/bindings/c/src/blob_to_kzg_commitment.rs
+++ b/bindings/c/src/blob_to_kzg_commitment.rs
@@ -1,10 +1,10 @@
 use eip7594::constants::{BYTES_PER_BLOB, BYTES_PER_COMMITMENT};
 
 use crate::pointer_utils::{create_array_ref, deref_const, write_to_slice};
-use crate::{CResult, PeerDASContext};
+use crate::{CResult, DASContext};
 
 pub(crate) fn _blob_to_kzg_commitment(
-    ctx: *const PeerDASContext,
+    ctx: *const DASContext,
     blob: *const u8,
     out: *mut u8,
 ) -> Result<(), CResult> {

--- a/bindings/c/src/compute_cells_and_kzg_proofs.rs
+++ b/bindings/c/src/compute_cells_and_kzg_proofs.rs
@@ -1,9 +1,9 @@
 use crate::pointer_utils::{create_array_ref, deref_const, write_to_2d_slice};
-use crate::{CResult, PeerDASContext};
+use crate::{CResult, DASContext};
 use eip7594::constants::{BYTES_PER_BLOB, CELLS_PER_EXT_BLOB};
 
 pub(crate) fn _compute_cells_and_kzg_proofs(
-    ctx: *const PeerDASContext,
+    ctx: *const DASContext,
     blob: *const u8,
     out_cells: *mut *mut u8,
     out_proofs: *mut *mut u8,

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -18,29 +18,29 @@ pub use eip7594::constants::{
 };
 use eip7594::Error;
 
-// This is a wrapper around the PeerDASContext from the eip7594 library.
+// This is a wrapper around the DASContext from the eip7594 library.
 // We need to wrap it as some bindgen tools cannot pick up items
 // not defined in this file.
 #[derive(Default)]
-pub struct PeerDASContext {
-    inner: eip7594::PeerDASContext,
+pub struct DASContext {
+    inner: eip7594::DASContext,
 }
 
-impl PeerDASContext {
-    pub fn inner(&self) -> &eip7594::PeerDASContext {
+impl DASContext {
+    pub fn inner(&self) -> &eip7594::DASContext {
         &self.inner
     }
 }
 
-/// Create a new PeerDASContext and return a pointer to it.
+/// Create a new DASContext and return a pointer to it.
 ///
 /// # Memory faults
 ///
 /// To avoid memory leaks, one should ensure that the pointer is freed after use
 /// by calling `peerdas_context_free`.
 #[no_mangle]
-pub extern "C" fn peerdas_context_new() -> *mut PeerDASContext {
-    let ctx = Box::<PeerDASContext>::default();
+pub extern "C" fn peerdas_context_new() -> *mut DASContext {
+    let ctx = Box::<DASContext>::default();
     Box::into_raw(ctx)
 }
 
@@ -59,7 +59,7 @@ pub extern "C" fn peerdas_context_new() -> *mut PeerDASContext {
 /// a pointer that was not created by `peerdas_context_new`.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
-pub extern "C" fn peerdas_context_free(ctx: *mut PeerDASContext) {
+pub extern "C" fn peerdas_context_free(ctx: *mut DASContext) {
     if ctx.is_null() {
         return;
     }
@@ -146,7 +146,7 @@ pub unsafe extern "C" fn free_error_message(c_message: *mut std::os::raw::c_char
 #[no_mangle]
 #[must_use]
 pub extern "C" fn blob_to_kzg_commitment(
-    ctx: *const PeerDASContext,
+    ctx: *const DASContext,
 
     blob: *const u8,
 
@@ -176,7 +176,7 @@ pub extern "C" fn blob_to_kzg_commitment(
 #[no_mangle]
 #[must_use]
 pub extern "C" fn compute_cells_and_kzg_proofs(
-    ctx: *const PeerDASContext,
+    ctx: *const DASContext,
 
     blob: *const u8,
 
@@ -231,7 +231,7 @@ fn verification_result_to_bool_cresult(
 #[no_mangle]
 #[must_use]
 pub extern "C" fn verify_cell_kzg_proof_batch(
-    ctx: *const PeerDASContext,
+    ctx: *const DASContext,
 
     row_commitments_length: u64,
     row_commitments: *const *const u8,
@@ -294,7 +294,7 @@ pub extern "C" fn verify_cell_kzg_proof_batch(
 #[no_mangle]
 #[must_use]
 pub extern "C" fn recover_cells_and_proofs(
-    ctx: *const PeerDASContext,
+    ctx: *const DASContext,
 
     cells_length: u64,
     cells: *const *const u8,

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -37,9 +37,9 @@ impl DASContext {
 /// # Memory faults
 ///
 /// To avoid memory leaks, one should ensure that the pointer is freed after use
-/// by calling `peerdas_context_free`.
+/// by calling `das_context_free`.
 #[no_mangle]
-pub extern "C" fn peerdas_context_new() -> *mut DASContext {
+pub extern "C" fn das_context_new() -> *mut DASContext {
     let ctx = Box::<DASContext>::default();
     Box::into_raw(ctx)
 }
@@ -56,10 +56,10 @@ pub extern "C" fn peerdas_context_new() -> *mut DASContext {
 /// # Undefined behavior
 ///
 /// - Since the `ctx` is created in Rust, we can only get undefined behavior, if the caller passes in
-/// a pointer that was not created by `peerdas_context_new`.
+/// a pointer that was not created by `das_context_new`.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
-pub extern "C" fn peerdas_context_free(ctx: *mut DASContext) {
+pub extern "C" fn das_context_free(ctx: *mut DASContext) {
     if ctx.is_null() {
         return;
     }

--- a/bindings/c/src/recover_cells_and_kzg_proofs.rs
+++ b/bindings/c/src/recover_cells_and_kzg_proofs.rs
@@ -1,11 +1,11 @@
 use crate::pointer_utils::{
     create_slice_view, deref_const, ptr_ptr_to_vec_slice_const, write_to_2d_slice,
 };
-use crate::{CResult, PeerDASContext};
+use crate::{CResult, DASContext};
 use eip7594::constants::{BYTES_PER_CELL, CELLS_PER_EXT_BLOB};
 
 pub(crate) fn _recover_cells_and_proofs(
-    ctx: *const PeerDASContext,
+    ctx: *const DASContext,
     cells_length: u64,
     cells: *const *const u8,
     cell_indices_length: u64,

--- a/bindings/c/src/verify_cells_and_kzg_proofs_batch.rs
+++ b/bindings/c/src/verify_cells_and_kzg_proofs_batch.rs
@@ -1,10 +1,10 @@
 use crate::pointer_utils::{create_slice_view, deref_const, deref_mut, ptr_ptr_to_vec_slice_const};
-use crate::{verification_result_to_bool_cresult, CResult, PeerDASContext};
+use crate::{verification_result_to_bool_cresult, CResult, DASContext};
 use eip7594::constants::{BYTES_PER_CELL, BYTES_PER_COMMITMENT};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn _verify_cell_kzg_proof_batch(
-    ctx: *const PeerDASContext,
+    ctx: *const DASContext,
 
     row_commitments_length: u64,
     row_commitments: *const *const u8,

--- a/bindings/csharp/csharp_code/PeerDASKZG.bindings/native_methods.g.cs
+++ b/bindings/csharp/csharp_code/PeerDASKZG.bindings/native_methods.g.cs
@@ -23,10 +23,10 @@ namespace PeerDAS.Native
         ///  # Memory faults
         ///
         ///  To avoid memory leaks, one should ensure that the pointer is freed after use
-        ///  by calling `peerdas_context_free`.
+        ///  by calling `das_context_free`.
         /// </summary>
-        [DllImport(__DllName, EntryPoint = "peerdas_context_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern DASContext* peerdas_context_new();
+        [DllImport(__DllName, EntryPoint = "das_context_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern DASContext* das_context_new();
 
         /// <summary>
         ///  # Safety
@@ -41,10 +41,10 @@ namespace PeerDAS.Native
         ///  # Undefined behavior
         ///
         ///  - Since the `ctx` is created in Rust, we can only get undefined behavior, if the caller passes in
-        ///  a pointer that was not created by `peerdas_context_new`.
+        ///  a pointer that was not created by `das_context_new`.
         /// </summary>
-        [DllImport(__DllName, EntryPoint = "peerdas_context_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern void peerdas_context_free(DASContext* ctx);
+        [DllImport(__DllName, EntryPoint = "das_context_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern void das_context_free(DASContext* ctx);
 
         /// <summary>
         ///  Free the memory allocated for the error message.

--- a/bindings/csharp/csharp_code/PeerDASKZG.bindings/native_methods.g.cs
+++ b/bindings/csharp/csharp_code/PeerDASKZG.bindings/native_methods.g.cs
@@ -18,7 +18,7 @@ namespace PeerDAS.Native
 
 
         /// <summary>
-        ///  Create a new PeerDASContext and return a pointer to it.
+        ///  Create a new DASContext and return a pointer to it.
         ///
         ///  # Memory faults
         ///
@@ -26,7 +26,7 @@ namespace PeerDAS.Native
         ///  by calling `peerdas_context_free`.
         /// </summary>
         [DllImport(__DllName, EntryPoint = "peerdas_context_new", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern PeerDASContext* peerdas_context_new();
+        internal static extern DASContext* peerdas_context_new();
 
         /// <summary>
         ///  # Safety
@@ -44,7 +44,7 @@ namespace PeerDAS.Native
         ///  a pointer that was not created by `peerdas_context_new`.
         /// </summary>
         [DllImport(__DllName, EntryPoint = "peerdas_context_free", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern void peerdas_context_free(PeerDASContext* ctx);
+        internal static extern void peerdas_context_free(DASContext* ctx);
 
         /// <summary>
         ///  Free the memory allocated for the error message.
@@ -72,7 +72,7 @@ namespace PeerDAS.Native
         ///    If the other arguments are null, this method will dereference a null pointer and result in undefined behavior.
         /// </summary>
         [DllImport(__DllName, EntryPoint = "blob_to_kzg_commitment", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern CResult blob_to_kzg_commitment(PeerDASContext* ctx, byte* blob, byte* @out);
+        internal static extern CResult blob_to_kzg_commitment(DASContext* ctx, byte* blob, byte* @out);
 
         /// <summary>
         ///  Computes the cells and KZG proofs for a given blob.
@@ -92,7 +92,7 @@ namespace PeerDAS.Native
         ///    If the other arguments are null, this method will dereference a null pointer and result in undefined behavior.
         /// </summary>
         [DllImport(__DllName, EntryPoint = "compute_cells_and_kzg_proofs", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern CResult compute_cells_and_kzg_proofs(PeerDASContext* ctx, byte* blob, byte** out_cells, byte** out_proofs);
+        internal static extern CResult compute_cells_and_kzg_proofs(DASContext* ctx, byte* blob, byte** out_cells, byte** out_proofs);
 
         /// <summary>
         ///  Verifies a batch of cells and their KZG proofs.
@@ -122,7 +122,7 @@ namespace PeerDAS.Native
         ///    If the other arguments are null, this method will dereference a null pointer and result in undefined behavior.
         /// </summary>
         [DllImport(__DllName, EntryPoint = "verify_cell_kzg_proof_batch", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern CResult verify_cell_kzg_proof_batch(PeerDASContext* ctx, ulong row_commitments_length, byte** row_commitments, ulong row_indices_length, ulong* row_indices, ulong column_indices_length, ulong* column_indices, ulong cells_length, byte** cells, ulong proofs_length, byte** proofs, bool* verified);
+        internal static extern CResult verify_cell_kzg_proof_batch(DASContext* ctx, ulong row_commitments_length, byte** row_commitments, ulong row_indices_length, ulong* row_indices, ulong column_indices_length, ulong* column_indices, ulong cells_length, byte** cells, ulong proofs_length, byte** proofs, bool* verified);
 
         /// <summary>
         ///  Recovers all cells and their KZG proofs from the given cell indices and cells
@@ -149,7 +149,7 @@ namespace PeerDAS.Native
         ///    If the other arguments are null, this method will dereference a null pointer and result in undefined behavior.
         /// </summary>
         [DllImport(__DllName, EntryPoint = "recover_cells_and_proofs", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        internal static extern CResult recover_cells_and_proofs(PeerDASContext* ctx, ulong cells_length, byte** cells, ulong cell_indices_length, ulong* cell_indices, byte** out_cells, byte** out_proofs);
+        internal static extern CResult recover_cells_and_proofs(DASContext* ctx, ulong cells_length, byte** cells, ulong cell_indices_length, ulong* cell_indices, byte** out_cells, byte** out_proofs);
 
         [DllImport(__DllName, EntryPoint = "constant_bytes_per_cell", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         internal static extern ulong constant_bytes_per_cell();
@@ -164,7 +164,7 @@ namespace PeerDAS.Native
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    internal unsafe partial struct PeerDASContext
+    internal unsafe partial struct DASContext
     {
     }
 

--- a/bindings/csharp/csharp_code/PeerDASKZG.bindings/peerdaskzg.cs
+++ b/bindings/csharp/csharp_code/PeerDASKZG.bindings/peerdaskzg.cs
@@ -26,7 +26,7 @@ public sealed unsafe class PeerDASKZG : IDisposable
     // The number of bytes in a single cell.
     public const int BytesPerCell = 2048;
 
-    private PeerDASContext* _context;
+    private DASContext* _context;
 
     public PeerDASKZG()
     {

--- a/bindings/csharp/csharp_code/PeerDASKZG.bindings/peerdaskzg.cs
+++ b/bindings/csharp/csharp_code/PeerDASKZG.bindings/peerdaskzg.cs
@@ -30,14 +30,14 @@ public sealed unsafe class PeerDASKZG : IDisposable
 
     public PeerDASKZG()
     {
-        _context = peerdas_context_new();
+        _context = das_context_new();
     }
 
     public void Dispose()
     {
         if (_context != null)
         {
-            peerdas_context_free(_context);
+            das_context_free(_context);
             _context = null;
         }
     }

--- a/bindings/golang/prover.go
+++ b/bindings/golang/prover.go
@@ -41,21 +41,21 @@ const (
 	BytesPerCell = 2048
 )
 
-type PeerDASContext struct {
-	_inner *C.PeerDASContext
+type DASContext struct {
+	_inner *C.DASContext
 }
 
-func NewProverContext() *PeerDASContext {
-	self := &PeerDASContext{_inner: C.peerdas_context_new()}
+func NewProverContext() *DASContext {
+	self := &DASContext{_inner: C.peerdas_context_new()}
 
-	runtime.SetFinalizer(self, func(self *PeerDASContext) {
+	runtime.SetFinalizer(self, func(self *DASContext) {
 		C.peerdas_context_free(self.inner())
 	})
 
 	return self
 }
 
-func (prover *PeerDASContext) BlobToKZGCommitment(blob []byte) ([]byte, error) {
+func (prover *DASContext) BlobToKZGCommitment(blob []byte) ([]byte, error) {
 	if len(blob) != BytesPerBlob {
 		return nil, errors.New("invalid blob size")
 	}
@@ -64,6 +64,6 @@ func (prover *PeerDASContext) BlobToKZGCommitment(blob []byte) ([]byte, error) {
 	return out, nil
 }
 
-func (prover *PeerDASContext) inner() *C.PeerDASContext {
+func (prover *DASContext) inner() *C.DASContext {
 	return prover._inner
 }

--- a/bindings/golang/prover.go
+++ b/bindings/golang/prover.go
@@ -46,10 +46,10 @@ type DASContext struct {
 }
 
 func NewProverContext() *DASContext {
-	self := &DASContext{_inner: C.peerdas_context_new()}
+	self := &DASContext{_inner: C.das_context_new()}
 
 	runtime.SetFinalizer(self, func(self *DASContext) {
-		C.peerdas_context_free(self.inner())
+		C.das_context_free(self.inner())
 	})
 
 	return self

--- a/bindings/java/java_code/src/main/java/ethereum/cryptography/LibPeerDASKZG.java
+++ b/bindings/java/java_code/src/main/java/ethereum/cryptography/LibPeerDASKZG.java
@@ -30,7 +30,7 @@ public class LibPeerDASKZG implements AutoCloseable{
 
     public LibPeerDASKZG() {
         ensureLibraryLoaded();
-        this.contextPtr = peerDASContextNew();
+        this.contextPtr = DASContextNew();
     }
 
     private static void ensureLibraryLoaded() {
@@ -54,7 +54,7 @@ public class LibPeerDASKZG implements AutoCloseable{
 
     public void destroy() {
         if (contextPtr != 0) {
-            peerDASContextDestroy(contextPtr);
+            DASContextDestroy(contextPtr);
             contextPtr = 0;
         }
     }
@@ -94,9 +94,9 @@ public class LibPeerDASKZG implements AutoCloseable{
      * library
      */
 
-    private static native long peerDASContextNew();
+    private static native long DASContextNew();
 
-    private static native void peerDASContextDestroy(long ctx_ptr);
+    private static native void DASContextDestroy(long ctx_ptr);
 
     private static native CellsAndProofs computeCellsAndKZGProofs(long context_ptr, byte[] blob);
 

--- a/bindings/java/rust_code/ethereum_cryptography_LibPeerDASKZG.h
+++ b/bindings/java/rust_code/ethereum_cryptography_LibPeerDASKZG.h
@@ -21,18 +21,18 @@ extern "C" {
 #define ethereum_cryptography_LibPeerDASKZG_BYTES_PER_CELL 2048L
 /*
  * Class:     ethereum_cryptography_LibPeerDASKZG
- * Method:    peerDASContextNew
+ * Method:    DASContextNew
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextNew
+JNIEXPORT jlong JNICALL Java_ethereum_cryptography_LibPeerDASKZG_DASContextNew
   (JNIEnv *, jclass);
 
 /*
  * Class:     ethereum_cryptography_LibPeerDASKZG
- * Method:    peerDASContextDestroy
+ * Method:    DASContextDestroy
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextDestroy
+JNIEXPORT void JNICALL Java_ethereum_cryptography_LibPeerDASKZG_DASContextDestroy
   (JNIEnv *, jclass, jlong);
 
 /*

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -8,22 +8,22 @@ mod errors;
 use errors::Error;
 
 #[no_mangle]
-pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextNew(
+pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_DASContextNew(
     _env: JNIEnv,
     _class: JClass,
 ) -> jlong {
     // TODO: Switch to using the Rust DASContext object
-    c_peerdas_kzg::peerdas_context_new() as jlong
+    c_peerdas_kzg::das_context_new() as jlong
 }
 
 #[no_mangle]
-pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextDestroy(
+pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_DASContextDestroy(
     _env: JNIEnv,
     _class: JClass,
     ctx_ptr: jlong,
 ) {
     // TODO: Switch to using the Rust DASContext object
-    c_peerdas_kzg::peerdas_context_free(ctx_ptr as *mut DASContext);
+    c_peerdas_kzg::das_context_free(ctx_ptr as *mut DASContext);
 }
 
 #[no_mangle]

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -22,7 +22,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextDe
     _class: JClass,
     ctx_ptr: jlong,
 ) {
-    // TODO: Switch to using the Rust PeerDASContext object
+    // TODO: Switch to using the Rust DASContext object
     c_peerdas_kzg::peerdas_context_free(ctx_ptr as *mut DASContext);
 }
 

--- a/bindings/java/rust_code/src/lib.rs
+++ b/bindings/java/rust_code/src/lib.rs
@@ -1,4 +1,4 @@
-use c_peerdas_kzg::PeerDASContext;
+use c_peerdas_kzg::DASContext;
 use jni::objects::JObjectArray;
 use jni::objects::{JByteArray, JClass, JLongArray, JObject, JValue};
 use jni::sys::{jboolean, jlong};
@@ -12,7 +12,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextNe
     _env: JNIEnv,
     _class: JClass,
 ) -> jlong {
-    // TODO: Switch to using the Rust PeerDASContext object
+    // TODO: Switch to using the Rust DASContext object
     c_peerdas_kzg::peerdas_context_new() as jlong
 }
 
@@ -23,7 +23,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_peerDASContextDe
     ctx_ptr: jlong,
 ) {
     // TODO: Switch to using the Rust PeerDASContext object
-    c_peerdas_kzg::peerdas_context_free(ctx_ptr as *mut PeerDASContext);
+    c_peerdas_kzg::peerdas_context_free(ctx_ptr as *mut DASContext);
 }
 
 #[no_mangle]
@@ -33,7 +33,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_computeCellsAndK
     ctx_ptr: jlong,
     blob: JByteArray<'local>,
 ) -> JObject<'local> {
-    let ctx = unsafe { &*(ctx_ptr as *const PeerDASContext) };
+    let ctx = unsafe { &*(ctx_ptr as *const DASContext) };
     match compute_cells_and_kzg_proofs(&mut env, ctx, blob) {
         Ok(cells_and_proofs) => cells_and_proofs,
         Err(err) => {
@@ -44,7 +44,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_computeCellsAndK
 }
 fn compute_cells_and_kzg_proofs<'local>(
     env: &mut JNIEnv<'local>,
-    ctx: &PeerDASContext,
+    ctx: &DASContext,
     blob: JByteArray<'local>,
 ) -> Result<JObject<'local>, Error> {
     let blob = env.convert_byte_array(blob)?;
@@ -62,7 +62,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_blobToKZGCommitm
     ctx_ptr: jlong,
     blob: JByteArray<'local>,
 ) -> JByteArray<'local> {
-    let ctx = unsafe { &*(ctx_ptr as *const PeerDASContext) };
+    let ctx = unsafe { &*(ctx_ptr as *const DASContext) };
     match blob_to_kzg_commitment(&mut env, ctx, blob) {
         Ok(commitment) => commitment,
         Err(err) => {
@@ -73,7 +73,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_blobToKZGCommitm
 }
 fn blob_to_kzg_commitment<'local>(
     env: &mut JNIEnv<'local>,
-    ctx: &PeerDASContext,
+    ctx: &DASContext,
     blob: JByteArray<'local>,
 ) -> Result<JByteArray<'local>, Error> {
     let blob = env.convert_byte_array(blob)?;
@@ -94,7 +94,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_verifyCellKZGPro
     cells: JObjectArray<'local>,
     proofs: JObjectArray<'local>,
 ) -> jboolean {
-    let ctx = unsafe { &*(ctx_ptr as *const PeerDASContext) };
+    let ctx = unsafe { &*(ctx_ptr as *const DASContext) };
 
     match verify_cell_kzg_proof_batch(
         &mut env,
@@ -114,7 +114,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_verifyCellKZGPro
 }
 fn verify_cell_kzg_proof_batch<'local>(
     env: &mut JNIEnv,
-    ctx: &PeerDASContext,
+    ctx: &DASContext,
     commitment: JObjectArray<'local>,
     row_indices: JLongArray,
     column_indices: JLongArray,
@@ -161,7 +161,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_recoverCellsAndP
     cell_ids: JLongArray,
     cells: JObjectArray<'local>,
 ) -> JObject<'local> {
-    let ctx = unsafe { &*(ctx_ptr as *const PeerDASContext) };
+    let ctx = unsafe { &*(ctx_ptr as *const DASContext) };
 
     match recover_cells_and_kzg_proofs(&mut env, ctx, cell_ids, cells) {
         Ok(cells_and_proofs) => cells_and_proofs,
@@ -173,7 +173,7 @@ pub extern "system" fn Java_ethereum_cryptography_LibPeerDASKZG_recoverCellsAndP
 }
 fn recover_cells_and_kzg_proofs<'local>(
     env: &mut JNIEnv<'local>,
-    ctx: &PeerDASContext,
+    ctx: &DASContext,
     cell_ids: JLongArray,
     cells: JObjectArray<'local>,
 ) -> Result<JObject<'local>, Error> {

--- a/bindings/nim/nim_code/nim_peerdas_kzg/header.nim
+++ b/bindings/nim/nim_code/nim_peerdas_kzg/header.nim
@@ -21,8 +21,8 @@ type CResult* = object
 # # Memory faults
 #
 # To avoid memory leaks, one should ensure that the pointer is freed after use
-# by calling `peerdas_context_free`.
-proc peerdas_context_new*(): ptr DASContext {.importc: "peerdas_context_new".}
+# by calling `das_context_free`.
+proc das_context_new*(): ptr DASContext {.importc: "das_context_new".}
 
 ## # Safety
 #
@@ -36,8 +36,8 @@ proc peerdas_context_new*(): ptr DASContext {.importc: "peerdas_context_new".}
 # # Undefined behavior
 #
 # - Since the `ctx` is created in Rust, we can only get undefined behavior, if the caller passes in
-# a pointer that was not created by `peerdas_context_new`.
-proc peerdas_context_free*(ctx: ptr DASContext): void {.importc: "peerdas_context_free".}
+# a pointer that was not created by `das_context_new`.
+proc das_context_free*(ctx: ptr DASContext): void {.importc: "das_context_free".}
 
 ## Free the memory allocated for the error message.
 #

--- a/bindings/nim/nim_code/nim_peerdas_kzg/header.nim
+++ b/bindings/nim/nim_code/nim_peerdas_kzg/header.nim
@@ -7,7 +7,7 @@ type CResultStatus* = enum
   Ok
   Err
 
-type PeerDASContext* {.incompleteStruct.} = object
+type DASContext* {.incompleteStruct.} = object
 
 ## A C-style struct to represent the success result of a function call.
 #
@@ -16,13 +16,13 @@ type CResult* = object
   xstatus*: CResultStatus
   xerror_msg*: pointer
 
-## Create a new PeerDASContext and return a pointer to it.
+## Create a new DASContext and return a pointer to it.
 #
 # # Memory faults
 #
 # To avoid memory leaks, one should ensure that the pointer is freed after use
 # by calling `peerdas_context_free`.
-proc peerdas_context_new*(): ptr PeerDASContext {.importc: "peerdas_context_new".}
+proc peerdas_context_new*(): ptr DASContext {.importc: "peerdas_context_new".}
 
 ## # Safety
 #
@@ -37,7 +37,7 @@ proc peerdas_context_new*(): ptr PeerDASContext {.importc: "peerdas_context_new"
 #
 # - Since the `ctx` is created in Rust, we can only get undefined behavior, if the caller passes in
 # a pointer that was not created by `peerdas_context_new`.
-proc peerdas_context_free*(ctx: ptr PeerDASContext): void {.importc: "peerdas_context_free".}
+proc peerdas_context_free*(ctx: ptr DASContext): void {.importc: "peerdas_context_free".}
 
 ## Free the memory allocated for the error message.
 #
@@ -59,7 +59,7 @@ proc free_error_message*(c_message: pointer): void {.importc: "free_error_messag
 #
 # - This implementation will check if the ctx pointer is null, but it will not check if the other arguments are null.
 #   If the other arguments are null, this method will dereference a null pointer and result in undefined behavior.
-proc blob_to_kzg_commitment*(ctx: ptr PeerDASContext,
+proc blob_to_kzg_commitment*(ctx: ptr DASContext,
                              blob: pointer,
                              outx: pointer): CResult {.importc: "blob_to_kzg_commitment".}
 
@@ -78,7 +78,7 @@ proc blob_to_kzg_commitment*(ctx: ptr PeerDASContext,
 #
 # - This implementation will check if the ctx pointer is null, but it will not check if the other arguments are null.
 #   If the other arguments are null, this method will dereference a null pointer and result in undefined behavior.
-proc compute_cells_and_kzg_proofs*(ctx: ptr PeerDASContext,
+proc compute_cells_and_kzg_proofs*(ctx: ptr DASContext,
                                    blob: pointer,
                                    out_cells: ptr pointer,
                                    out_proofs: ptr pointer): CResult {.importc: "compute_cells_and_kzg_proofs".}
@@ -108,7 +108,7 @@ proc compute_cells_and_kzg_proofs*(ctx: ptr PeerDASContext,
 #
 # - This implementation will check if the ctx pointer is null, but it will not check if the other arguments are null.
 #   If the other arguments are null, this method will dereference a null pointer and result in undefined behavior.
-proc verify_cell_kzg_proof_batch*(ctx: ptr PeerDASContext,
+proc verify_cell_kzg_proof_batch*(ctx: ptr DASContext,
                                   row_commitments_length: uint64,
                                   row_commitments: ptr pointer,
                                   row_indices_length: uint64,
@@ -143,7 +143,7 @@ proc verify_cell_kzg_proof_batch*(ctx: ptr PeerDASContext,
 #
 # - This implementation will check if the ctx pointer is null, but it will not check if the other arguments are null.
 #   If the other arguments are null, this method will dereference a null pointer and result in undefined behavior.
-proc recover_cells_and_proofs*(ctx: ptr PeerDASContext,
+proc recover_cells_and_proofs*(ctx: ptr DASContext,
                                cells_length: uint64,
                                cells: ptr pointer,
                                cell_indices_length: uint64,

--- a/bindings/nim/nim_code/nim_peerdas_kzg/nim_peerdas_kzg.nim
+++ b/bindings/nim/nim_code/nim_peerdas_kzg/nim_peerdas_kzg.nim
@@ -83,11 +83,11 @@ type
 # https://forum.nim-lang.org/t/11229
 proc `=destroy`(x: typeof KZGCtx()[]) =
   if x.ctx_ptr != nil:
-    peerdas_context_free(x.ctx_ptr)
+    das_context_free(x.ctx_ptr)
 
 proc newKZGCtx*(): KZGCtx =
   var kzgCtx = KZGCtx()
-  kzgCtx.ctx_ptr = peerdas_context_new()
+  kzgCtx.ctx_ptr = das_context_new()
   return kzgCtx
 
 

--- a/bindings/nim/nim_code/nim_peerdas_kzg/nim_peerdas_kzg.nim
+++ b/bindings/nim/nim_code/nim_peerdas_kzg/nim_peerdas_kzg.nim
@@ -74,7 +74,7 @@ template verify_result(res: CResult, ret: untyped): untyped =
 
 type
   KZGCtx* = ref object
-    ctx_ptr: ptr PeerDASContext
+    ctx_ptr: ptr DASContext
 
 # Define custom destructor
 # Nim2 does not allow us to take in a var T

--- a/bindings/node/__test__/index.spec.ts
+++ b/bindings/node/__test__/index.spec.ts
@@ -1,6 +1,5 @@
 import {
-  PeerDasContextJs,
-  PeerDASContextJs,
+  DasContextJs,
 } from "../index.js";
 
 import { readFileSync } from "fs";
@@ -60,8 +59,8 @@ function assertBytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): void 
   }
 }
 
-describe("ProverContext", () => {
-  const ctx = new PeerDasContextJs();
+describe("Spec tests", () => {
+  const ctx = new DasContextJs();
 
   it("reference tests for blobToKzgCommitment should pass", () => {
     const tests = globSync(BLOB_TO_KZG_COMMITMENT_TESTS);

--- a/bindings/node/src/lib.rs
+++ b/bindings/node/src/lib.rs
@@ -6,7 +6,7 @@ use napi::{
 };
 use napi_derive::napi;
 
-use eip7594::{constants, PeerDASContext};
+use eip7594::{constants, DASContext};
 
 #[napi]
 pub const BYTES_PER_COMMITMENT: u32 = constants::BYTES_PER_COMMITMENT as u32;
@@ -28,22 +28,22 @@ pub struct CellsAndProofs {
 }
 
 #[napi]
-pub struct PeerDASContextJs {
-  inner: Arc<PeerDASContext>,
+pub struct DASContextJs {
+  inner: Arc<DASContext>,
 }
 
-impl Default for PeerDASContextJs {
+impl Default for DASContextJs {
   fn default() -> Self {
     Self::new()
   }
 }
 
 #[napi]
-impl PeerDASContextJs {
+impl DASContextJs {
   #[napi(constructor)]
   pub fn new() -> Self {
-    PeerDASContextJs {
-      inner: Arc::new(PeerDASContext::default()),
+    DASContextJs {
+      inner: Arc::new(DASContext::default()),
     }
   }
 

--- a/eip7594/benches/benchmark.rs
+++ b/eip7594/benches/benchmark.rs
@@ -2,7 +2,7 @@ use bls12_381::Scalar;
 use criterion::{criterion_group, criterion_main, Criterion};
 use eip7594::{
     constants::{BYTES_PER_BLOB, CELLS_PER_EXT_BLOB},
-    Bytes48Ref, Cell, CellIndex, CellRef, KZGCommitment, KZGProof, PeerDASContext, RowIndex,
+    Bytes48Ref, Cell, CellIndex, CellRef, DASContext, KZGCommitment, KZGProof, RowIndex,
     TrustedSetup,
 };
 
@@ -23,7 +23,7 @@ fn dummy_commitment_cells_and_proofs() -> (
     KZGCommitment,
     ([Cell; CELLS_PER_EXT_BLOB], [KZGProof; CELLS_PER_EXT_BLOB]),
 ) {
-    let ctx = PeerDASContext::default();
+    let ctx = DASContext::default();
     let blob = dummy_blob();
 
     let commitment = ctx.blob_to_kzg_commitment(&blob).unwrap();
@@ -38,7 +38,7 @@ pub fn bench_compute_cells_and_kzg_proofs(c: &mut Criterion) {
     let blob = dummy_blob();
 
     for num_threads in THREAD_COUNTS {
-        let ctx = PeerDASContext::with_threads(&trusted_setup, num_threads);
+        let ctx = DASContext::with_threads(&trusted_setup, num_threads);
         c.bench_function(
             &format!(
                 "computing cells_and_kzg_proofs - NUM_THREADS: {}",
@@ -64,7 +64,7 @@ pub fn bench_recover_cells_and_compute_kzg_proofs(c: &mut Criterion) {
         .collect::<Vec<_>>();
 
     for num_threads in THREAD_COUNTS {
-        let ctx = PeerDASContext::with_threads(&trusted_setup, num_threads);
+        let ctx = DASContext::with_threads(&trusted_setup, num_threads);
         c.bench_function(
             &format!(
                 "worse-case recover_cells_and_compute_proofs - NUM_THREADS: {}",
@@ -91,7 +91,7 @@ pub fn bench_verify_cell_kzg_proof_batch(c: &mut Criterion) {
     let proof_refs: Vec<Bytes48Ref> = proofs.iter().map(|proof| proof).collect();
 
     for num_threads in THREAD_COUNTS {
-        let ctx = PeerDASContext::with_threads(&trusted_setup, num_threads);
+        let ctx = DASContext::with_threads(&trusted_setup, num_threads);
         c.bench_function(
             &format!("verify_cell_kzg_proof_batch - NUM_THREADS: {}", num_threads),
             |b| {
@@ -114,7 +114,7 @@ pub fn bench_init_context(c: &mut Criterion) {
     c.bench_function(&format!("Initialize context"), |b| {
         b.iter(|| {
             let trusted_setup = TrustedSetup::default();
-            PeerDASContext::with_threads(&trusted_setup, NUM_THREADS)
+            DASContext::with_threads(&trusted_setup, NUM_THREADS)
         })
     });
 }

--- a/eip7594/src/lib.rs
+++ b/eip7594/src/lib.rs
@@ -30,21 +30,21 @@ use verifier::VerifierContext;
 
 /// The context that will be used to create and verify proofs.
 #[derive(Debug)]
-pub struct PeerDASContext {
+pub struct DASContext {
     thread_pool: Arc<ThreadPool>,
     pub prover_ctx: ProverContext,
     pub verifier_ctx: VerifierContext,
 }
 
-impl Default for PeerDASContext {
+impl Default for DASContext {
     fn default() -> Self {
         let trusted_setup = TrustedSetup::default();
         const DEFAULT_NUM_THREADS: usize = 1;
-        PeerDASContext::with_threads(&trusted_setup, DEFAULT_NUM_THREADS)
+        DASContext::with_threads(&trusted_setup, DEFAULT_NUM_THREADS)
     }
 }
 
-impl PeerDASContext {
+impl DASContext {
     pub fn with_threads(trusted_setup: &TrustedSetup, num_threads: usize) -> Self {
         let thread_pool = std::sync::Arc::new(
             rayon::ThreadPoolBuilder::new()
@@ -53,7 +53,7 @@ impl PeerDASContext {
                 .unwrap(),
         );
 
-        PeerDASContext {
+        DASContext {
             thread_pool,
             prover_ctx: ProverContext::new(trusted_setup),
             verifier_ctx: VerifierContext::new(trusted_setup),

--- a/eip7594/src/prover.rs
+++ b/eip7594/src/prover.rs
@@ -13,7 +13,7 @@ use crate::{
         deserialize_blob_to_scalars, serialize_cells_and_proofs, serialize_g1_compressed,
     },
     trusted_setup::TrustedSetup,
-    BlobRef, Cell, CellIndex, CellRef, KZGCommitment, KZGProof, PeerDASContext,
+    BlobRef, Cell, CellIndex, CellRef, KZGCommitment, KZGProof, DASContext,
 };
 
 /// Context object that is used to call functions in the prover API.
@@ -57,7 +57,7 @@ impl ProverContext {
     }
 }
 
-impl PeerDASContext {
+impl DASContext {
     /// Computes the KZG commitment to the polynomial represented by the blob.
     pub fn blob_to_kzg_commitment(&self, blob: BlobRef) -> Result<KZGCommitment, Error> {
         self.thread_pool.install(|| {

--- a/eip7594/src/verifier.rs
+++ b/eip7594/src/verifier.rs
@@ -9,7 +9,7 @@ use crate::{
     errors::Error,
     serialization::{deserialize_cells, deserialize_compressed_g1_points},
     trusted_setup::TrustedSetup,
-    Bytes48Ref, CellIndex, CellRef, PeerDASContext, RowIndex,
+    Bytes48Ref, CellIndex, CellRef, DASContext, RowIndex,
 };
 use bls12_381::Scalar;
 use erasure_codes::{BlockErasureIndices, ReedSolomon};
@@ -64,7 +64,7 @@ fn find_missing_cell_indices(present_cell_indices: &[usize]) -> Vec<usize> {
     missing
 }
 
-impl PeerDASContext {
+impl DASContext {
     /// Given a collection of commitments, cells and proofs, this functions verifies that
     /// the cells are consistent with the commitments using their respective KZG proofs.
     pub fn verify_cell_kzg_proof_batch(

--- a/eip7594/tests/blob_to_kzg_commitment.rs
+++ b/eip7594/tests/blob_to_kzg_commitment.rs
@@ -62,7 +62,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/blob_to_kzg_commitment";
 fn test_blob_to_kzg_commitment() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let ctx = eip7594::PeerDASContext::default();
+    let ctx = eip7594::DASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).unwrap();

--- a/eip7594/tests/compute_cells_and_kzg_proofs.rs
+++ b/eip7594/tests/compute_cells_and_kzg_proofs.rs
@@ -76,7 +76,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/compute_cells_and_kzg_proofs";
 fn test_compute_cells_and_kzg_proofs() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let ctx = eip7594::PeerDASContext::default();
+    let ctx = eip7594::DASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(test_file).unwrap();

--- a/eip7594/tests/recover_cells_and_compute_proofs.rs
+++ b/eip7594/tests/recover_cells_and_compute_proofs.rs
@@ -81,7 +81,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/recover_cells_and_kzg_proofs";
 fn test_recover_cells_and_proofs() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let ctx = eip7594::PeerDASContext::default();
+    let ctx = eip7594::DASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(&test_file).unwrap();

--- a/eip7594/tests/verify_cell_kzg_proof_batch.rs
+++ b/eip7594/tests/verify_cell_kzg_proof_batch.rs
@@ -84,7 +84,7 @@ const TEST_DIR: &str = "../consensus_test_vectors/verify_cell_kzg_proof_batch";
 fn test_verify_cell_kzg_proof_batch() {
     let test_files = collect_test_files(TEST_DIR).unwrap();
 
-    let ctx = eip7594::PeerDASContext::default();
+    let ctx = eip7594::DASContext::default();
 
     for test_file in test_files {
         let yaml_data = fs::read_to_string(&test_file).unwrap();


### PR DESCRIPTION
Pulled out from #89 

This library will include 4844 functions in the near future, so this premptively removes the PeerDAS prefic, for just DAS